### PR TITLE
Fixing Top Headlines

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -74,4 +74,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
+
+    implementation 'com.squareup.okhttp3:okhttp:3.12.2'
+    implementation 'com.squareup.okhttp3:logging-interceptor:3.11.0'
 }

--- a/app/src/main/java/yodgorbek/komilov/musobaqayangiliklari/MainActivity.kt
+++ b/app/src/main/java/yodgorbek/komilov/musobaqayangiliklari/MainActivity.kt
@@ -19,20 +19,22 @@ import yodgorbek.komilov.musobaqayangiliklari.ui.TopHeadlinesFragment
 
 class MainActivity : AppCompatActivity() {
 
-
-
+    var selectedFragment = Fragment()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-       val  bottomNavigationView = findViewById<BottomNavigationView>(R.id.bottom)
+        val  bottomNavigationView = findViewById<BottomNavigationView>(R.id.bottom)
 
+        selectedFragment = TopHeadlinesFragment()
 
+        val transaction = supportFragmentManager.beginTransaction()
+        transaction.replace(R.id.frame_layout, selectedFragment)
+        transaction.commit()
 
         bottomNavigationView.setOnNavigationItemSelectedListener {
 
-            var selectedFragment = Fragment()
             when (it.itemId) {
                 R.id.top_headline -> selectedFragment = TopHeadlinesFragment()
 

--- a/app/src/main/java/yodgorbek/komilov/musobaqayangiliklari/internet/SportNewsInterface.kt
+++ b/app/src/main/java/yodgorbek/komilov/musobaqayangiliklari/internet/SportNewsInterface.kt
@@ -1,9 +1,12 @@
 package yodgorbek.komilov.musobaqayangiliklari.internet
 
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Call
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.http.GET
+import java.util.concurrent.TimeUnit
 
 interface SportNewsInterface {
 
@@ -25,9 +28,20 @@ interface SportNewsInterface {
 
         fun create(): SportNewsInterface {
 
+            val interceptor = HttpLoggingInterceptor()
+            interceptor.setLevel(HttpLoggingInterceptor.Level.BODY)
+
+            val client = OkHttpClient.Builder()
+                .addInterceptor(interceptor)
+                .connectTimeout(60, TimeUnit.SECONDS)
+                .readTimeout(60, TimeUnit.SECONDS)
+                .writeTimeout(30, TimeUnit.SECONDS)
+                .build()
+
             val retrofit = Retrofit.Builder()
                 .addConverterFactory(GsonConverterFactory.create())
                 .baseUrl(BASE_URL)
+                .client(client)
                 .build()
             return retrofit.create(SportNewsInterface::class.java)
 

--- a/app/src/main/java/yodgorbek/komilov/musobaqayangiliklari/model/Source.kt
+++ b/app/src/main/java/yodgorbek/komilov/musobaqayangiliklari/model/Source.kt
@@ -1,6 +1,6 @@
 package yodgorbek.komilov.musobaqayangiliklari.model
 
 data class Source(
-    val id: Any,
+    val id: Any?,
     val name: String
 )

--- a/app/src/main/java/yodgorbek/komilov/musobaqayangiliklari/ui/TopHeadlinesFragment.kt
+++ b/app/src/main/java/yodgorbek/komilov/musobaqayangiliklari/ui/TopHeadlinesFragment.kt
@@ -34,6 +34,8 @@ class TopHeadlinesFragment : Fragment() {
         )
 
        val recyclerView = view.findViewById (R.id.recyclerView) as RecyclerView
+        topHeadlinesAdapter = TopHeadlinesAdapter(recyclerView.context)
+
         recyclerView.layoutManager = LinearLayoutManager(context)
         recyclerView.adapter = topHeadlinesAdapter
 
@@ -47,7 +49,9 @@ class TopHeadlinesFragment : Fragment() {
                 response: Response<SportNewsResponse>?
             ) {
 
-                if (response!!.body() != null) topHeadlinesAdapter!!.setMovieListItems(response.body()!!.articles)
+                if (response!!.body() != null) {
+                    topHeadlinesAdapter!!.setMovieListItems(response.body()!!.articles)
+                }
             }
 
             override fun onFailure(call: Call<SportNewsResponse>?, t: Throwable?) {
@@ -57,7 +61,6 @@ class TopHeadlinesFragment : Fragment() {
         return view
 
     }
-
 
 
 }


### PR DESCRIPTION
- Adding Logging for OkHttp so, I can view my request and response on logcat in tag "OkHttp"

- Set logging on retrofit

- I set for first time load activity to load TopHeadLines